### PR TITLE
Use FactoryGirl.lint instead of specs for test code

### DIFF
--- a/README.md
+++ b/README.md
@@ -874,15 +874,7 @@ easier understanding and reading of a test.
     end
     ```
 
-* Add an example ensuring that the FactoryGirl.created model is valid.
-
-    ```ruby
-    describe Article do
-      it 'is valid with valid attributes' do
-        expect(article).to be_valid
-      end
-    end
-    ```
+* Use [FactoryGirl.lint](https://github.com/thoughtbot/factory_girl/blob/master/GETTING_STARTED.md#linting-factories) to ensure that all Factories are valid.
 
 * When testing validations, use `have(x).errors_on` to specify the attibute
   which should be validated. Using `be_valid` does not guarantee that the 


### PR DESCRIPTION
Writing specs for test code is a slippery slope/code smell in itself. 
FactoryGirl.lint is executed outside the suite and has the additional
benefit of testing the validity of all factories.